### PR TITLE
API Get Models By Category Changes

### DIFF
--- a/api/Serializers/serializers.py
+++ b/api/Serializers/serializers.py
@@ -1,9 +1,10 @@
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 
+from api.Models.tools_category_model import ToolsCategory
+from api.Models.tools_history_model import ToolsHistory
 from api.Models.tools_model import Tools
 from api.Models.tools_model_model import ToolsModel
-from api.Models.tools_history_model import ToolsHistory
 
 
 class ToolsSerializer(ModelSerializer):
@@ -23,8 +24,13 @@ class ToolsModelSerializer(ModelSerializer):
 
 
 class ToolsHistorySerializer(ModelSerializer):
-
     class Meta:
         model = ToolsHistory
         exclude = ('user',)
         depth = 3
+
+
+class ToolsCategorySerializer(ModelSerializer):
+    class Meta:
+        model = ToolsCategory
+        fields = '__all__'

--- a/api/Views/ToolsView.py
+++ b/api/Views/ToolsView.py
@@ -46,8 +46,8 @@ class GetToolsByCategory(APIView):
     View responsible for returning a list of tools given a category.
     """
 
-    def get(self, request):
-        return ToolsHandler.handler_get_tools_by_category(request)
+    def get(self, request, category_id):
+        return ToolsHandler.handler_get_tools_by_category(category_id)
 
 
 class GetToolsHistoryByUser(APIView):
@@ -61,3 +61,11 @@ class GetToolsHistoryByUser(APIView):
 
     def get(self, request):
         return ToolsHandler.handler_get_tools_history_by_user(request.user)
+
+class GetAllCategories(APIView):
+    """
+        View responsible for returning a list of all categories.
+        """
+
+    def get(self, request):
+        return ToolsHandler.handler_get_all_categories()

--- a/api/urls.py
+++ b/api/urls.py
@@ -6,16 +6,18 @@ from api.Views.ToolsView import (GetAllTools,
                                  GetToolsModelById,
                                  GetTool,
                                  GetToolsByCategory,
-                                 GetToolsHistoryByUser
+                                 GetToolsHistoryByUser,
+                                 GetAllCategories
                                  )
 
 urlpatterns = [
     path('Tools/Models/Get/All', GetAllToolsModels.as_view()),
     path('Tools/Models/Get/<int:model_id>', GetToolsModelById.as_view()),
-    path('Tools/Models/Get/ByCategory', GetToolsByCategory.as_view()),
+    path('Tools/Models/Get/ByCategory/<int:category_id>', GetToolsByCategory.as_view()),
     path('Tools/Get/All', GetAllTools.as_view()),
     path('Tools/Get/<int:tool_id>', GetTool.as_view(), name='get_tool_by_id'),
     path('Tools/History/Get/ByUser', GetToolsHistoryByUser.as_view()),
+    path('Tools/Category/Get/All', GetAllCategories.as_view()),
 
 ]
 

--- a/core/CustomErrors/CustomErrors.py
+++ b/core/CustomErrors/CustomErrors.py
@@ -14,7 +14,7 @@ class CustomError:
         "GE-0": ("Exception Raised:", "Something went wrong, please try again later or contact support."),
         "TC-0": ("Tool Category not found. Exception raised:", "Category not found."),
         "TC-1": ("No tools was found for this category. Exception raised:", "No tools found for this category."),
-        "TC-2": ("Missing category name parameter. Exception raised:", "Missing category name on request."),
+        "TC-2": ("Missing category parameter. Exception raised:", "Missing category on request."),
         "TM-0": ("Model not found. Exception raised:", "No model was found for this id."),
         "TM-2": ("Missing category name parameter. Exception raised:", "Missing category name on request."),
 

--- a/core/ToolsManager/ToolsHandler.py
+++ b/core/ToolsManager/ToolsHandler.py
@@ -2,7 +2,8 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from api.Models.tools_model_model import ToolsModel
-from api.Serializers.serializers import (ToolsSerializer, ToolsModelSerializer, ToolsHistorySerializer)
+from api.Serializers.serializers import (ToolsSerializer, ToolsModelSerializer, ToolsHistorySerializer,
+                                         ToolsCategorySerializer)
 from core.CustomErrors.CustomErrors import CustomError
 from core.ToolsManager.ToolsHelper import ToolsHelper
 
@@ -72,14 +73,13 @@ class ToolsHandler:
                              "dev_error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
     @staticmethod
-    def handler_get_tools_by_category(request):
+    def handler_get_tools_by_category(category_id):
         try:
-            category_name = request.GET.get('category_name')
 
-            if not category_name:
+            if not category_id:
                 return Response(CustomError.get_error_by_code("TC-2"), status=status.HTTP_400_BAD_REQUEST)
 
-            category = ToolsHelper.get_tool_category_by_name(category_name)
+            category = ToolsHelper.get_tool_category_by_id(category_id)
             if not category.exists():
                 return Response(CustomError.get_error_by_code("TC-0"), status=status.HTTP_400_BAD_REQUEST)
             category = category.first()
@@ -111,3 +111,9 @@ class ToolsHandler:
         except Exception as e:
             return Response({'user_error': "Something went wrong, please try again later or contact support.",
                              "dev_error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+    @staticmethod
+    def handler_get_all_categories():
+        category_objects = ToolsHelper.get_all_categories()
+        category_serializer = ToolsCategorySerializer(category_objects, many=True)
+        return Response(category_serializer.data, status=status.HTTP_200_OK)

--- a/core/ToolsManager/ToolsHelper.py
+++ b/core/ToolsManager/ToolsHelper.py
@@ -42,8 +42,8 @@ class ToolsHelper:
         return Tools.objects.get(id=id)
 
     @staticmethod
-    def get_tool_category_by_name(category_name):
-        return ToolsCategory.objects.filter(name=category_name)
+    def get_tool_category_by_id(category_id):
+        return ToolsCategory.objects.filter(pk=category_id)
 
     @staticmethod
     def get_tools_models_by_category(category):
@@ -90,3 +90,11 @@ class ToolsHelper:
         :return:
         """
         return queryset.annotate(amount_available=Count(F("tools__id"), filter=Q(tools__available=True)))
+
+    @staticmethod
+    def get_all_categories():
+        """
+        Return a queryset of all ToolsCategory objects.
+        :return:
+        """
+        return ToolsCategory.objects.all()


### PR DESCRIPTION
Changed API Get Tools Model By Category to expect category ID instead of name.

Added new API to return a list of all Categories.