### PR TITLE
Hotfix Checkout Review

### DIFF
--- a/core/PaymentManager/PaymentHandler.py
+++ b/core/PaymentManager/PaymentHandler.py
@@ -208,6 +208,10 @@ class PaymentHandler:
 
                     if cart_quantity > items_per_model[model]:
                         amount_to_add = cart_quantity - items_per_model[model]
+                        if amount_to_add > available:
+                            amount_to_add = available
+                            quantity_error_msg[
+                                model] = f"Not enough tools. There are only {items_per_model[model] + available} of this tool available."
                         amount_to_add = available if amount_to_add > available else amount_to_add
 
                 else:
@@ -278,10 +282,11 @@ class PaymentHandler:
                         item.tool.available = True
                         item.tool.save()
                         item.delete()
+                        counter -= 1
 
                 # Calculate SubTotal
-                if cart_quantity > 0:
-                    rental_order.sub_total += (cart_quantity * price * time_rented)
+                if counter > 0:
+                    rental_order.sub_total += (counter * price * time_rented)
 
             rental_order.save()
             checkout_ser = CheckoutSerializer(rental_order, context={'error_list': quantity_error_msg})

--- a/payment/Serializers/serializers.py
+++ b/payment/Serializers/serializers.py
@@ -51,11 +51,11 @@ class CheckoutSerializer(ModelSerializer):
         if error_list:
             for model in tools_models:
                 model_id = model["tool__model_id"]
-                model["error_msg"] = error_list[model_id]
+                model["error_msg"] = error_list.get(model_id)
 
             if tools_models.exists() is False:
                 return [{"tool__model_id": model_id,
-                         "error_msg": error_list[model_id],
+                         "error_msg": error_list.get(model_id),
                          "time_rented": None,
                          "quantity": None} for model_id in error_list]
 


### PR DESCRIPTION
Checkout Review API was crashing when at least one of the items in the RentalOrderItem had an error and another doesn't.